### PR TITLE
Add launch file for pt cloud lsr scan and robot body filter

### DIFF
--- a/nightingale_perception/config/movo_body_filter.yaml
+++ b/nightingale_perception/config/movo_body_filter.yaml
@@ -1,0 +1,14 @@
+cloud_filter_chain:
+- name: movo_filter
+  type: robot_body_filter/RobotBodyFilterPointcloud2
+  params:
+     frames/fixed: "odom"
+     frames/sensor: "camera_link"
+     frames/filtering: "camera_link"
+     frames/output: "camera_link"
+     sensor/min_distance: 0.05
+     body_model/inflation/scale: 1.05
+     body_model/inflation/padding: 0.02
+     filter/do_shadow/test: True
+     #filter/model_pose_update_interval: 0.005 # arbitrary update interval selected for now
+     # only_links: [] LIST LINKS THAT ARE NEEDED TO BE CHECKED -> SHOULD ONLY BE ARM LINKS

--- a/nightingale_perception/launch/movo_body_filter.launch
+++ b/nightingale_perception/launch/movo_body_filter.launch
@@ -1,0 +1,24 @@
+<!-- launch file for point cloud laser scan conversion and filtering of robot body
+<launch>
+
+  <!-- Point cloud body filter node -->
+  <node name="pointcloud_filter" pkg="sensor_filters" type="pointcloud2_filter_chain">
+      <rosparam command="load" file="../config/movo_body_filter.yaml" />
+  
+      <remap from="~input" to="/camera/depth/color/points" />
+      <remap from="~output" to="/camera/depth/color/points_filtered" />
+  </node>
+
+  <!-- Point cloud to laser scan conversion -->
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan_node">
+      <remap from="/cloud_in" to="/camera/depth/color/points_filtered"/>
+
+      <rosparam>
+          #target_frame: camera_link
+          min_height: 0.0
+          max_height: 2.0
+      </rosparam>
+  </node>
+
+
+</launch>


### PR DESCRIPTION
Adding point cloud to laser scan conversion for navigation purposes. Ability to detect objects which are not vertically uniform such as tables.

Adding robot body filter to point cloud since robot arms will interfere with perception

documentation here: https://bdschnap.atlassian.net/wiki/spaces/FYDP/pages/32079906/Camera+laser+scan+point+cloud+fusion

Packages used: http://wiki.ros.org/pointcloud_to_laserscan http://wiki.ros.org/robot_body_filter