### PR TITLE
Add compile check for nightingale repo

### DIFF
--- a/.github/workflows/colcon_compile_nightingale.yaml
+++ b/.github/workflows/colcon_compile_nightingale.yaml
@@ -1,0 +1,32 @@
+name: ros_colcon_CI_nightingale
+on: [push, pull_request]
+
+env:
+  PACKAGES_TO_TEST:
+    nightingale_teleop
+    
+
+jobs:
+  compile:
+    name: ROS 1 CI Action
+    runs-on: [ubuntu-20.04]
+
+    container:
+      image: ubuntu:focal
+      options: -u root
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@0.4.1
+        with:
+          required-ros-distributions: noetic
+
+      - name: Run CI
+        uses: ros-tooling/action-ros-ci@0.2.7
+        with:
+          target-ros1-distro: noetic
+          package-name: ${{ env.PACKAGES_TO_TEST }}
+          skip-tests: true


### PR DESCRIPTION
Adding compile check for nightingale repo in preparation for new packages and application code. Copied the code from the kinova fork and added the packages of this repo's main branch