### PR TITLE
Clean up v0

### DIFF
--- a/nightingale.rosinstall
+++ b/nightingale.rosinstall
@@ -9,3 +9,23 @@ repositories:
     url: https://github.com/aws-robotics/aws-robomaker-hospital-world.git
     version: ros1
 
+  rosbridge-suite:
+    type: git
+    url: https://github.com/RobotWebTools/rosbridge_suite.git
+    version: ros1
+
+  robot-body-filter:
+    type: git
+    url: https://github.com/peci1/robot_body_filter.git
+    version: master
+
+  pointcloud-to-laserscan:
+    type: git
+    url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+    version: lunar-devel
+
+  ira-laser-tools:
+    type: git
+    url: https://github.com/iralabdisco/ira_laser_tools.git
+    version: ros1-master
+

--- a/nightingale.rosinstall
+++ b/nightingale.rosinstall
@@ -8,24 +8,3 @@ repositories:
     type: git
     url: https://github.com/aws-robotics/aws-robomaker-hospital-world.git
     version: ros1
-
-  rosbridge-suite:
-    type: git
-    url: https://github.com/RobotWebTools/rosbridge_suite.git
-    version: ros1
-
-  robot-body-filter:
-    type: git
-    url: https://github.com/peci1/robot_body_filter.git
-    version: master
-
-  pointcloud-to-laserscan:
-    type: git
-    url: https://github.com/ros-perception/pointcloud_to_laserscan.git
-    version: lunar-devel
-
-  ira-laser-tools:
-    type: git
-    url: https://github.com/iralabdisco/ira_laser_tools.git
-    version: ros1-master
-

--- a/nightingale.rosinstall
+++ b/nightingale.rosinstall
@@ -8,3 +8,8 @@ repositories:
     type: git
     url: https://github.com/aws-robotics/aws-robomaker-hospital-world.git
     version: ros1
+
+  moveit_action_handlers:
+    type: git
+    url: https://github.com/panagelak/moveit_action_handlers.git
+    version: main

--- a/nightingale_dispatcher/src/nightingale_dispatcher/dispatcher.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/dispatcher.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
+import queue
 import rospy
 import actionlib
 
-import queue
 from actionlib.simple_action_client import SimpleGoalState
 from nightingale_msgs.msg import MissionPlanAction, MissionPlanGoal
 from nightingale_msgs.srv import AddMissionPlan, AddMissionPlanResponse

--- a/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-
-import rospy
-import actionlib
 import queue
 from enum import Enum
 
+import rospy
+import actionlib
 from actionlib_msgs.msg import GoalStatus
 from std_msgs.msg import String
 from nightingale_msgs.msg import MissionPlanAction
@@ -46,7 +45,7 @@ class MissionPlanner(PhaseStatus):
         # TODO: first go to doorside then bedside when door opening added
 
         # update to driving screen
-        self.send_interface_request_task.execute(RobotStatus.DRIVING)
+        task_reponse = self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute(self.room, "bedside")
         if status == TaskCodes.ERROR:
@@ -60,7 +59,7 @@ class MissionPlanner(PhaseStatus):
         # TODO: first go to doorside then bedside when door opening added
 
         # update to driving screen
-        self.send_interface_request_task.execute(RobotStatus.DRIVING)
+        task_reponse = self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute("home", "default")
         if status == TaskCodes.ERROR:
@@ -94,7 +93,7 @@ class MissionPlanner(PhaseStatus):
         rospy.loginfo("Nightingale Mission Planner going to stock")
 
         # update to driving screen
-        self.send_interface_request_task.execute(RobotStatus.DRIVING)
+        task_reponse = self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute("stock", "default")
         if status == TaskCodes.ERROR:
@@ -118,6 +117,8 @@ class MissionPlanner(PhaseStatus):
         joint_values = self.cfg["right_arm_home"]["joints"]
         status = self.move_arm_task.execute(joint_values)
 
+        # add a block to check arm status first before interpreting input
+
         if task_reponse == TaskCodes.ERROR:
             raise NotImplementedError()
         elif task_reponse == TaskCodes.DELIVER_ITEMS:
@@ -138,7 +139,7 @@ class MissionPlanner(PhaseStatus):
         # TODO: first go to doorside then bedside when door opening added
 
         # update to driving screen
-        self.send_interface_request_task.execute(RobotStatus.DRIVING)
+        task_reponse = self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute(self.room, "bedside")
         if status == TaskCodes.ERROR:
@@ -176,6 +177,8 @@ class MissionPlanner(PhaseStatus):
             RobotStatus.ARM_RETRACTED
         )
 
+        # add a block to check arm status first before interpreting input
+
         if status == TaskCodes.ERROR:
             raise NotImplementedError()
         # when done automatically goes back to triage patient
@@ -185,11 +188,12 @@ class MissionPlanner(PhaseStatus):
     def go_idle_phase(self):
         # cleanup and exit
         # Update idle screen
-        status = self.send_interface_request_task.execute(RobotStatus.IDLE_HOME)
+        task_response = self.send_interface_request_task.execute(RobotStatus.IDLE_HOME)
 
         # move arms to home position?
+        # add a block to check arm status first before interpreting input
 
-        if status == TaskCodes.ERROR:
+        if task_response == TaskCodes.ERROR:
             raise NotImplementedError()
         return PhaseStatus.PHASE_COMPLETE
 

--- a/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
@@ -20,14 +20,13 @@ class PhaseStatus(Enum):
     PHASE_FAIL = 0
 
 
-class MissionPlanner(PhaseStatus):
+class MissionPlanner:
     def __init__(self):
         rospy.init_node("mission_planner_node")
 
         self.estop_sub = rospy.Subscriber(
             BridgeConfig.USER_INPUT_TOPIC, String, self.estop_cb
         )
-        self.cfg = rospy.get_param("/nightingale_utils/joint_configurations")
         self.navigate_task = NavigateTask()
         self.move_arm_task = MoveArmTask()
         self.send_interface_request_task = SendInterfaceRequestTask()

--- a/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
@@ -11,7 +11,7 @@ from nightingale_msgs.msg import MissionPlanAction
 from nightingale_dispatcher.navigate_task import NavigateTask
 from nightingale_dispatcher.move_arm_task import MoveArmTask
 from nightingale_dispatcher.send_interface_request_task import SendInterfaceRequestTask
-from nightingale_dispatcher.task import Task
+from nightingale_dispatcher.task import Task, TaskCodes
 from nightingale_ros_bridge.bridge_interface_config import BridgeConfig, RobotStatus
 
 
@@ -49,7 +49,7 @@ class MissionPlanner(PhaseStatus):
         self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute(self.room, "bedside")
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         self.phases.put(self.triage_patient_phase)
         return PhaseStatus.PHASE_COMPLETE
@@ -63,7 +63,7 @@ class MissionPlanner(PhaseStatus):
         self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute("home", "default")
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         self.phases.put(self.go_idle_phase)
         return PhaseStatus.PHASE_COMPLETE
@@ -76,12 +76,12 @@ class MissionPlanner(PhaseStatus):
             RobotStatus.BEDSIDE_IDLE
         )
 
-        if task_response == Task.ERROR:
+        if task_response == TaskCodes.ERROR:
             raise NotImplementedError()
-        if task_response == Task.WD_TIMEOUT or task_response == Task.DISMISS:
+        if task_response == TaskCodes.WD_TIMEOUT or task_response == TaskCodes.DISMISS:
             # User didn't want anything or timedout
             self.phases.put(self.go_home_base_phase)
-        elif task_response == Task.STOCK_ITEMS:
+        elif task_response == TaskCodes.STOCK_ITEMS:
             # User wants some items
             self.phases.put(self.go_to_stock_phase)
         else:
@@ -97,7 +97,7 @@ class MissionPlanner(PhaseStatus):
         self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute("stock", "default")
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         self.phases.put(self.get_items_phase)
         return PhaseStatus.PHASE_COMPLETE
@@ -118,11 +118,11 @@ class MissionPlanner(PhaseStatus):
         joint_values = self.cfg["right_arm_home"]["joints"]
         status = self.move_arm_task.execute(joint_values)
 
-        if task_reponse == Task.ERROR:
+        if task_reponse == TaskCodes.ERROR:
             raise NotImplementedError()
-        elif task_reponse == Task.DELIVER_ITEMS:
+        elif task_reponse == TaskCodes.DELIVER_ITEMS:
             self.phases.put(self.return_to_patient_phase)
-        elif task_reponse == Task.DISMISS:
+        elif task_reponse == TaskCodes.DISMISS:
             # nurse cancelled
             self.phases.put(self.go_home_base_phase)
         else:
@@ -141,7 +141,7 @@ class MissionPlanner(PhaseStatus):
         self.send_interface_request_task.execute(RobotStatus.DRIVING)
 
         status = self.navigate_task.execute(self.room, "bedside")
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         self.phases.put(self.handoff_items_phase)
         return PhaseStatus.PHASE_COMPLETE
@@ -176,7 +176,7 @@ class MissionPlanner(PhaseStatus):
             RobotStatus.ARM_RETRACTED
         )
 
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         # when done automatically goes back to triage patient
         self.phases.put(self.triage_patient_phase)
@@ -189,7 +189,7 @@ class MissionPlanner(PhaseStatus):
 
         # move arms to home position?
 
-        if status == Task.ERROR:
+        if status == TaskCodes.ERROR:
             raise NotImplementedError()
         return PhaseStatus.PHASE_COMPLETE
 

--- a/nightingale_dispatcher/src/nightingale_dispatcher/move_arm_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/move_arm_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import rospy
-from nightingale_dispatcher.task import Task
+from nightingale_dispatcher.task import Task, TaskCodes
 import actionlib
 from actionlib_msgs.msg import GoalStatus
 from nightingale_manipulation.manipulation_action_client import ManipulationControl

--- a/nightingale_dispatcher/src/nightingale_dispatcher/move_arm_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/move_arm_task.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-
-import rospy
-from nightingale_dispatcher.task import Task, TaskCodes
 import actionlib
 from actionlib_msgs.msg import GoalStatus
+import rospy
+from nightingale_dispatcher.task import Task, TaskCodes
 from nightingale_manipulation.manipulation_action_client import ManipulationControl
 
 
@@ -14,4 +13,4 @@ class MoveArmTask(Task):
     def execute(self, end_pose):
         assert len(end_pose) is 7
         self.manipulation.jnt_ctrl.cmd_right_arm(end_pose)
-        return Task.SUCCESS
+        return TaskCodes.SUCCESS

--- a/nightingale_dispatcher/src/nightingale_dispatcher/navigate_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/navigate_task.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-
-import rospy
-from nightingale_dispatcher.task import Task, TaskCodes
 import actionlib
 from actionlib_msgs.msg import GoalStatus
+import rospy
+from nightingale_dispatcher.task import Task, TaskCodes
 from nightingale_msgs.msg import RoomRunnerAction, RoomRunnerGoal
 
 

--- a/nightingale_dispatcher/src/nightingale_dispatcher/navigate_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/navigate_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import rospy
-from nightingale_dispatcher.task import Task
+from nightingale_dispatcher.task import Task, TaskCodes
 import actionlib
 from actionlib_msgs.msg import GoalStatus
 from nightingale_msgs.msg import RoomRunnerAction, RoomRunnerGoal
@@ -28,7 +28,7 @@ class NavigateTask(Task):
         self.action_client.send_goal(goal)
         self.action_client.wait_for_result()
         return (
-            Task.SUCCESS
+            TaskCodes.SUCCESS
             if self.action_client.get_state() == GoalStatus.SUCCEEDED
-            else Task.ERROR
+            else TaskCodes.ERROR
         )

--- a/nightingale_dispatcher/src/nightingale_dispatcher/send_interface_request_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/send_interface_request_task.py
@@ -23,7 +23,7 @@ class SendInterfaceRequestTask(Task):
             )
             interface_response = self.interface_comms_proxy(robot_state)
             input_code = interface_response.user_input
-            rospy.loginfo("USER INPUT %d", input_code)
+            rospy.loginfo(f"USER INPUT {input_code}")
             # convert input to return code
             status = Task.SUCCESS
             if input_code == UserInputs.STOCK_ITEMS:
@@ -39,4 +39,4 @@ class SendInterfaceRequestTask(Task):
                 pass
             return status
         except rospy.ServiceException as e:
-            rospy.logerr("Service call failed: %s", e)
+            rospy.logerr(f"Service call failed: {e}")

--- a/nightingale_dispatcher/src/nightingale_dispatcher/send_interface_request_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/send_interface_request_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import rospy
-from nightingale_dispatcher.task import Task
+from nightingale_dispatcher.task import Task, TaskCodes
 from nightingale_ros_bridge.bridge_interface_config import BridgeConfig, UserInputs
 from nightingale_msgs.srv import InterfaceCall
 
@@ -25,15 +25,15 @@ class SendInterfaceRequestTask(Task):
             input_code = interface_response.user_input
             rospy.loginfo(f"USER INPUT {input_code}")
             # convert input to return code
-            status = Task.SUCCESS
+            status = TaskCodes.SUCCESS
             if input_code == UserInputs.STOCK_ITEMS:
-                status = Task.STOCK_ITEMS
+                status = TaskCodes.STOCK_ITEMS
             elif input_code == UserInputs.DELIVER_ITEMS:
-                status = Task.DELIVER_ITEMS
+                status = TaskCodes.DELIVER_ITEMS
             elif input_code == UserInputs.RETURN_HOME:
-                status = Task.DISMISS
+                status = TaskCodes.DISMISS
             elif input_code == UserInputs.WD_TIMEOUT:
-                status = Task.WD_TIMEOUT
+                status = TaskCodes.WD_TIMEOUT
             elif input_code == UserInputs.NO_INPUT:
                 # return success
                 pass

--- a/nightingale_dispatcher/src/nightingale_dispatcher/task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/task.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
+from enum import Enum
 
 
-class Task:
+class Task(Enum):
     ERROR = -1
     SUCCESS = 0
     STOCK_ITEMS = 1

--- a/nightingale_dispatcher/src/nightingale_dispatcher/task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/task.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 from enum import Enum
 
-
-class Task(Enum):
+class TaskCodes(Enum):
+    # task codes for mission planner
     ERROR = -1
     SUCCESS = 0
     STOCK_ITEMS = 1
     DELIVER_ITEMS = 2
     DISMISS = 3
     WD_TIMEOUT = 9
+
+class Task():
+    # common code for tasks
+    is_task = True 

--- a/nightingale_dispatcher/src/nightingale_dispatcher/task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/task.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from enum import Enum
 
+
 class TaskCodes(Enum):
     # task codes for mission planner
     ERROR = -1
@@ -10,6 +11,7 @@ class TaskCodes(Enum):
     DISMISS = 3
     WD_TIMEOUT = 9
 
-class Task():
+
+class Task:
     # common code for tasks
-    is_task = True 
+    is_task = True

--- a/nightingale_manipulation/src/nightingale_manipulation/manipulation_action_client.py
+++ b/nightingale_manipulation/src/nightingale_manipulation/manipulation_action_client.py
@@ -22,7 +22,6 @@ from geometry_msgs.msg import Pose
 
 
 # TODO: replace with service call, requires refactoring of service to include gripper info
-CFG = rospy.get_param("/nightingale_utils/joint_configurations")
 
 
 def joint_goal(joint_values, joint_names, eev=0.5, eea=0.5, timeout=10):

--- a/nightingale_perception/package.xml
+++ b/nightingale_perception/package.xml
@@ -54,18 +54,21 @@
   <build_depend>robot_body_filter</build_depend>
   <build_depend>sensor_filters</build_depend>
   <build_depend>pointcloud_to_laserscan</build_depend>
+  <build_depend>ira_laser_tools</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>robot_body_filter</build_export_depend>
   <build_export_depend>sensor_filters</build_export_depend>
   <build_export_depend>pointcloud_to_laserscan</build_export_depend>
+  <build_export_depend>ira_laser_tools</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>robot_body_filter</exec_depend>
   <exec_depend>sensor_filters</exec_depend>
   <exec_depend>pointcloud_to_laserscan</exec_depend>
+  <exec_depend>ira_laser_tools</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/nightingale_perception/package.xml
+++ b/nightingale_perception/package.xml
@@ -53,16 +53,19 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>robot_body_filter</build_depend>
   <build_depend>sensor_filters</build_depend>
+  <build_depend>pointcloud_to_laserscan</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>robot_body_filter</build_export_depend>
   <build_export_depend>sensor_filters</build_export_depend>
+  <build_export_depend>pointcloud_to_laserscan</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>robot_body_filter</exec_depend>
   <exec_depend>sensor_filters</exec_depend>
+  <exec_depend>pointcloud_to_laserscan</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/nightingale_ros_bridge/package.xml
+++ b/nightingale_ros_bridge/package.xml
@@ -51,10 +51,13 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>rosbridge_suite</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>rosbridge_suite</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rosbridge_suite</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/nightingale_ros_bridge/src/nightingale_ros_bridge/ros_bridge_interface.py
+++ b/nightingale_ros_bridge/src/nightingale_ros_bridge/ros_bridge_interface.py
@@ -40,7 +40,6 @@ class RosBridgeInterface:
 
     # callback on M.P service call
     def interface_service_cb(self, request_data):
-        # rospy.loginfo(f"Received status {status}")
         # publish to UI tablet
         self.set_robot_status_pub.publish(str(request_data.status))
 


### PR DESCRIPTION
Cleaning up V0:

Things addressed:

return an Enum instead 1. meaning of enums is clearer
The class task should define python Enums (from enum import Enum) not the constants
nit: prefer f-strings over the % formatting u use https://www.google.com/search?q=python+fstring&oq=python+fstring&aqs=chrome..69i57j0i10i512l5j0i512j0i10i512l3.2496j0j7&sourceid=chrome&ie=UTF-8

Felix: Adding lyndons comments to address later: I'm not sure this is the best way to do this. Is to use a more generic Task constant that is general enough to apply to all tasks, then map the UserInput constants to the Task constants? If not, then it's better to just use the Task constants

Check and fix status conditions during each phase for mission planner

Add some necessary ros packages to rosinstall file