### PR TITLE
Remove arm init sim

### DIFF
--- a/nightingale_simulation/launch/simulation.launch
+++ b/nightingale_simulation/launch/simulation.launch
@@ -13,11 +13,6 @@
         args="5 movo_7dof_moveit_config movo_moveit_planning_execution.launch sim:=true info:=true"
         name="moveit_bringup" output="screen"/>
 
-    <!-- Run the simulation initialization procedure (ie tuck arms and more) -->
-    <node pkg="si_utils" type="timed_roslaunch"
-        args="10 movo_gazebo init_sim.xml"
-        name="init_sim_bringup" output="screen"/>
-
     <!-- Bring up RVIZ -->
     <node pkg="si_utils" type="timed_roslaunch"
         args="20 nightingale_visualization viz.launch"


### PR DESCRIPTION
Removed the timed launch of the arm init procedure since it interferes with the planning with the box. The launch file call I have replace only performs the arm init so no nightingale movo  functionality is lost.

Example movement with box after arm init removed. Arms start out in front but eventually mission planner will home the arms upon startup
![box_movement](https://user-images.githubusercontent.com/42899188/218274725-6615e5b5-5b98-4697-8858-1678409bf537.png)