### PR TITLE
reduce inflatino when close to goal + more features

### DIFF
--- a/nightingale_navigation/configs/costmap_common_params.yaml
+++ b/nightingale_navigation/configs/costmap_common_params.yaml
@@ -6,7 +6,8 @@ robot_base_frame:           base_link
 transform_tolerance:        0.5
 
 # ---Vector footprint (Meters):---
-footprint: [[0.39,0.3],[0.39,-0.3],[-0.39,-0.3],[-0.39,0.3]]
+#footprint: [[0.39,0.3],[0.39,-0.3],[-0.39,-0.3],[-0.39,0.3]]
+footprint: [[0.87,0.52],[0.87,-0.4],[-0.56,-0.4],[-0.56,0.52]]
 
 ### Costmap definitions ###
 update_frequency: 8.0 # laserscans are 15 Hz. Be conservative
@@ -15,5 +16,5 @@ inflation_radius: 0.45
 obstacle_layer/footprint_clearing_enabled: true
 
 #raytrace_range must be less than max range of sensor.
-observation_sources: scan_multi
-scan_multi: {data_type: LaserScan, topic: movo/scan_multi, marking: true, clearing: true, inf_is_valid: true, obstacle_range: 4.75, raytrace_range: 8.0}
+observation_sources: base_scan_filtered
+base_scan_filtered: {data_type: LaserScan, topic: movo/base_scan_filtered, marking: true, clearing: true, inf_is_valid: true, obstacle_range: 3.5, raytrace_range: 8.0}

--- a/nightingale_navigation/configs/move_base_params.yaml
+++ b/nightingale_navigation/configs/move_base_params.yaml
@@ -3,7 +3,7 @@
 #
 planner_frequency:          1.0     # default: 0.0 Global plan updates on new goal or path blocked only
 controller_frequency:       20.0    # default: 20.0
-planner_patience:           5.0     # default: 5.0
+planner_patience:           15.0    # default: 5.0
 controller_patience:        15.0    # default: 15.0
 conservative_reset_dist:    3.0     # default: 3.0
 recovery_behavior_enabled:  true    # default: true
@@ -15,8 +15,9 @@ oscillation_distance:       0.5     # default: 0.5
 
 recovery_behaviors: [
   {name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery},
-  {name: rotate_recovery1, type: rotate_recovery/RotateRecovery},
-  {name: aggressive_reset, type: clear_costmap_recovery/ClearCostmapRecovery},
+  {name: aggressive_reset1, type: clear_costmap_recovery/ClearCostmapRecovery},
+  {name: rotate_recovery, type: rotate_recovery/RotateRecovery},
+  {name: aggressive_reset2, type: clear_costmap_recovery/ClearCostmapRecovery},
 ]
 
 conservative_clear:

--- a/nightingale_navigation/launch/navigation.launch
+++ b/nightingale_navigation/launch/navigation.launch
@@ -19,5 +19,7 @@
         <param name="save_pose" value="false" />
         <param name="pose_filename" value="/home/$(optenv USER robohub)/.nightingale_room_runner_cache" />
         <param name="pose_write_period" value="10" />
+        <param name="deflation_hysteresis_low" value="2.5" />
+        <param name="deflation_hysteresis_high" value="7.0" />
     </node>
 </launch>


### PR DESCRIPTION
This PR does a couple of things:
1. This PR reduces the costmap inflation when the robot is < 2.5 meters away from the goal and inflates it back up when its more than 7 meters from the goal. this allows the robot to get up real close to the bed.
2. This PR increases the planner patience. The planner used to wait 5 seconds before beginning space clearing behaviors. it now waits 15 seconds. 
3. it increase sthe shape of the polygon the base uses during nav bc we now drive with a box
4. it moves rotational space clearing behavior until after an aggressive reset of the costmap is performed. the rotational clearing is desperate and should be done after the aggressive map reset. i also added another aggressive map reset after the rotational clearing
5. we now clear the costmaps on every navigation request. on thursday, i noticed that the robot would last see someone behind a hallway before it makes a turn and never sees them leave. so it assumes that person is still there which causes it to be unable to return home. clearing the costmap should leave only static obstacles and currently observable obstacles (in theory. i will test later)