### PR TITLE
Add error handling for pose estimation

### DIFF
--- a/nightingale_dispatcher/src/nightingale_dispatcher/estimate_pose_task.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/estimate_pose_task.py
@@ -25,12 +25,13 @@ class EstimatePoseTask(Task):
     def execute(self, target):
         goal = PoseEstimationGoal()
         goal.target = target
-        self.action_client.send_goal(goal)
-        self.action_client.wait_for_result()
-        result = self.action_client.get_result()
-        return (
-            TaskCodes.SUCCESS
-            if self.action_client.get_state() == GoalStatus.SUCCEEDED
-            else TaskCodes.ERROR,
-            result,
-        )
+        result = None
+        for _ in range(0, 3):
+            self.action_client.send_goal(goal)
+            self.action_client.wait_for_result()
+            result = self.action_client.get_result()
+            # allow retrial of the estimation in case cannot find pose
+            if self.action_client.get_state() == GoalStatus.SUCCEEDED:
+                return (TaskCodes.SUCCESS, result)
+
+        return (TaskCodes.ERROR, result)

--- a/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
+++ b/nightingale_dispatcher/src/nightingale_dispatcher/mission_planner.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+# /usr/bin/env python3
 import queue
 from enum import Enum
 
@@ -164,16 +164,16 @@ class MissionPlanner:
         # Arrived at patient's bedside
 
         # pose estimation
-        #status, pose_result = self.estimate_pose_task.execute("body")
-        #bin_goal_pt = pose_result.bin_goal.point
-        #rospy.loginfo(f"node returns {pose_result}")
-        # if unable to find patient pose place bin at predetermined position 
-        # could also abort and go home instead but this decision complexity 
+        # status, pose_result = self.estimate_pose_task.execute("body")
+        # bin_goal_pt = pose_result.bin_goal.point
+        # rospy.loginfo(f"node returns {pose_result}")
+        # if unable to find patient pose place bin at predetermined position
+        # could also abort and go home instead but this decision complexity
         # is likely not within current scope
-        #if status == TaskCodes.ERROR:
+        # if status == TaskCodes.ERROR:
         #    rospy.logwarn("UNABLE TO FIND POSE. FALLING BACK TO SAFE HANDOFF POSITION")
         #    #TODO Find a safe bin goal we can fall back on. currently the restock position
-        #    bin_goal_pt = self.fallback_bin_goal 
+        #    bin_goal_pt = self.fallback_bin_goal
 
         # show arm movement and get input to start
         task_response = self.send_interface_request_task.execute(
@@ -183,8 +183,8 @@ class MissionPlanner:
         # extend arm
         rospy.loginfo("Nightingale Mission Planner extending arm for handoff")
 
-        #UNCOMMENT FOR POSE GOAL
-        #if self.move_arm_task.extend_handoff(bin_goal_pt) != TaskCodes.SUCCESS:
+        # UNCOMMENT FOR POSE GOAL
+        # if self.move_arm_task.extend_handoff(bin_goal_pt) != TaskCodes.SUCCESS:
 
         if self.move_arm_task.extend_restock() != TaskCodes.SUCCESS:
             rospy.logerr("Nightingale Mission Planner failed to extend arm for handoff")

--- a/nightingale_msgs/action/PoseEstimation.action
+++ b/nightingale_msgs/action/PoseEstimation.action
@@ -5,6 +5,5 @@ string target
 # returns a 3D coordinate PointStamped
 # of the bin goal in base link frame
 geometry_msgs/PointStamped bin_goal
+int8 pose_est_fail
 ---
-# returns if issue getting pose or accurate coords 
-int8 pose_detect_failed


### PR DESCRIPTION
Adding error handling to pose estimation in case of perception failure. The pose estimation task will try to get the pose up to 3 times and will fail if this does not happen.

Behaviour is to go to a predefined position which is determined to likely be safe(currently set to the restock position).

For the time being, we should aim to ensure that there is always a good pose given to the robot(make sure a person is in a good position which shoulders clearly in view). This functionality should be important but with our demo being a video and the limited time, the error handling is not critical.

Merging int v1 test day so we have all of the code changes on a stable branch